### PR TITLE
Add theme overrides to prevent double rendering of page/post headers

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,9 @@
   <div class="wrapper">
     {%- assign default_paths = site.pages | map: "path" -%}
     {%- assign page_paths = site.header_pages | default: default_paths -%}
-    {%- assign titles_size = site.pages | map: 'title' | join: '' | size -%}
+    {%- comment -%} We coerce `titles_size` to 0 to prevent the navbar from getting littered with links
+      {%- assign titles_size = site.pages | map: 'title' | join: '' | size -%}
+    {%- endcomment -%}
     {%- assign titles_size = 0 -%}
     <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,36 @@
+---
+layout: default
+---
+
+<div class="home">
+  {%- comment -%} Do not create a heading here; we do that in the content itself. This creates a duplicate heading.
+    {%- if page.title -%}
+      <h1 class="page-heading">{{ page.title }}</h1>
+    {%- endif -%}
+  {%- endcomment -%}
+
+  {{ content }}
+
+  {%- if site.posts.size > 0 -%}
+    <h2 class="post-list-heading">{{ page.list_title | default: "Posts" }}</h2>
+    <ul class="post-list">
+      {%- for post in site.posts -%}
+      <li>
+        {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+        <span class="post-meta">{{ post.date | date: date_format }}</span>
+        <h3>
+          <a class="post-link" href="{{ post.url | relative_url }}">
+            {{ post.title | escape }}
+          </a>
+        </h3>
+        {%- if site.show_excerpts -%}
+          {{ post.excerpt }}
+        {%- endif -%}
+      </li>
+      {%- endfor -%}
+    </ul>
+
+    <p class="feed-subscribe"><svg class="svg-icon orange"><use xlink:href="{{ '/assets/minima-social-icons.svg#rss' | relative_url }}"></use></svg><a href="{{ "/feed.xml" | relative_url }}">Subscribe</a></p>
+  {%- endif -%}
+
+</div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,16 @@
+---
+layout: default
+---
+<article class="post">
+
+{%- comment -%} Do not create a heading here; we do that in the content itself. This creates a duplicate heading.
+  <header class="post-header">
+    <h1 class="post-title">{{ page.title | escape }}</h1>
+  </header>
+{%- endcomment -%}
+
+  <div class="post-content">
+    {{ content }}
+  </div>
+
+</article>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,0 +1,19 @@
+---
+---
+
+@import "minima";
+
+/**
+ * This is in the next (post-2.5.0) release of minima: https://github.com/jekyll/minima/pull/273
+ */
+.post-content {
+    h1 {
+        @include relative-font-size(2.625);
+        letter-spacing: -1px;
+        line-height: 1;
+
+        @media screen and (min-width: 800px) {
+            @include relative-font-size(2.625);
+        }
+    }
+}


### PR DESCRIPTION
And add comments to explain why we override the theme.