### PR TITLE
Get the CI build running and passing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,25 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.5.3
+    working_directory: ~/estimation
+    steps:
+      - checkout
+      - run:
+          name: Configure bundler
+          command: |
+            echo 'export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")' >> $BASH_ENV
+            source $BASH_ENV
+            gem install bundler
+      - run:
+          name: Install dependencies
+          command: bundle install
+      - run:
+          name: Run CI
+          command: bundle exec rake
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build

--- a/.mdl.style.rb
+++ b/.mdl.style.rb
@@ -1,0 +1,4 @@
+# Start with all rules
+all
+# Don't care about line length
+exclude_rule "MD013"

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,4 @@
+# Use our custom style ruleset
+style '.mdl.style.rb'
+# Jekyll requires front matter but mdl doesn't like it
+ignore_front_matter true

--- a/0000-work-estimation-record.md
+++ b/0000-work-estimation-record.md
@@ -44,8 +44,8 @@ An hour to a day
 
 The template will likely evolve over time, but its initial drafting took under a day (about an hour for Mike Giarlo to draft it initially, a 30ish minute meeting to intro the idea and refine it among six of the infra devs, a couple small touchup PRs, about 35 minutes to draft this PR).
 
-The template is here: https://github.com/sul-dlss-labs/estimation/blob/master/template.md
+The template is here: [https://github.com/sul-dlss-labs/estimation/blob/master/template.md](https://github.com/sul-dlss-labs/estimation/blob/master/template.md)
 
 Scope has expanded slightly, with the addition of this section. We hope it will provide a helpful way to spot trends in our analyses.
 
-Actual contributors (including via discussion) so far are: https://github.com/aaron-collier, https://github.com/jcoyne, https://github.com/jermnelson, https://github.com/jmartin-sul, https://github.com/justinlittman, https://github.com/mjgiarlo, https://github.com/ndushay
+Actual contributors (including via discussion) so far are: [@aaron-collier](https://github.com/aaron-collier), [@jcoyne](https://github.com/jcoyne), [@jermnelson](https://github.com/jermnelson), [@jmartin-sul](https://github.com/jmartin-sul), [@justinlittman](https://github.com/justinlittman), [@mjgiarlo](https://github.com/mjgiarlo), [@ndushay](https://github.com/ndushay)

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source 'https://rubygems.org'
 
+gem 'mdl'
+gem 'rake'
+
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem 'github-pages'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,6 +197,10 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    mdl (0.5.0)
+      kramdown (~> 1.12, >= 1.12.0)
+      mixlib-cli (~> 1.7, >= 1.7.0)
+      mixlib-config (~> 2.2, >= 2.2.1)
     mercenary (0.3.6)
     mini_portile2 (2.4.0)
     minima (2.5.0)
@@ -204,6 +208,9 @@ GEM
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.11.3)
+    mixlib-cli (1.7.0)
+    mixlib-config (2.2.18)
+      tomlrb
     multipart-post (2.0.0)
     nokogiri (1.10.2)
       mini_portile2 (~> 2.4.0)
@@ -212,6 +219,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.3)
+    rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -232,6 +240,7 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
+    tomlrb (1.2.8)
     typhoeus (1.3.1)
       ethon (>= 0.9.0)
     tzinfo (1.2.5)
@@ -244,6 +253,8 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   jekyll-feed (~> 0.6)
+  mdl
+  rake
 
 BUNDLED WITH
    2.0.1

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 - [WER-0000](0000-work-estimation-record.md) - Lightweight work estimation record.
 - [WER-0001](0001-cloud-resource-deployment.md) - Deploying lambdas and containers in AWS.
 
-# Process
+## Process
 
 Requests for work estimation should be written up as new pull requests, based on the [estimation template](template.md). Please follow these two practices in your pull requests:
 
 1. Name new WER files with the `nnnn-brief-summary-of-work.md` format; and
-2. Add a link to the new WER to `README.md`
+1. Add a link to the new WER to `README.md`
 
 If you feel your PR needs more than one review, include that information in the description section. (And, obviously, assign reviewers if you want particular reviewers.)
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+require 'mdl'
+
+task :lint do
+  MarkdownLint.run(['.'])
+end
+
+task default: :lint

--- a/template.md
+++ b/template.md
@@ -67,6 +67,7 @@ This is the amount of time estimated for the above team to tackle the work as de
 * \> 1 year
 
 Examples:
+
 * Between 1 hour and 1 week for 100% contact time of 2 engineers.
 * 3-9 months for a team of 4 engineers, each devoting 75% of his/her/their contact time.
 


### PR DESCRIPTION
Includes:

* Use `mdl` gem to lint/validate markdown files to prevent breaking the site
* Configure `mdl` to allow YAML front-matter (which we need for Jekyll) and ignore line length
* Execute default rake task (using bundler 2.0) in CI
  * Add rake dependency explicitly