### PR TITLE
a few more tweaks to the template

### DIFF
--- a/template.md
+++ b/template.md
@@ -14,6 +14,18 @@ Add enough information here to contextualize any information stated below, or a 
 
 Document scoping assumptions made and constraints given while producing the estimate. Surface these explicitly to ensure all parties have a shared understanding or what is included within, or without, the scope of the work.
 
+### Assumptions
+
+### Out of Scope
+
+## Work To Do
+
+Describe the work in more detail, broken down into chunks of work that help with determining estimate.
+
+### Stretch Goals
+
+(optional) Describe any closely related work that is not MVP but would be useful.  May be related to some 'Out of Scope' work above.
+
 ## Risks / Challenges / External Dependencies
 
 Write up potential risks, challenges, or external dependencies that could significantly affect the produced estimate.

--- a/template.md
+++ b/template.md
@@ -24,10 +24,11 @@ Assumptions in order to proceed with an approach to the work. Examples:
 - developers already know technologies (specify, e.g. javascript, React, Rails, terraform, whatever)
 
 ### Out of Scope
-Closely related work that this estimate does NOT include.  It may or may not be helpful to have "stretch" goals. Examples:
+Closely related work that this estimate does NOT include.  It may or may not be helpful to have "stretch" goals with optional associated estimates. Examples:
+
 - rebuilding the whole index from scratch (as opposed to incremental updates)
 - automating a task (plan is to do it manually at first)
-- providing a nice-to-have that is closely related (e.g. easy way for user to get list of all members in a group)
+- providing a nice-to-have that is closely related (e.g. easy way for user to get list of all members in a group; indexing another field; ...)
 
 ## Work To Do
 
@@ -35,10 +36,6 @@ Describe the work in more detail, broken down into chunks of work that help with
 - time to learn any new technologies (at least to the MVP level), e.g. terraform, new language, docker, rails ...
 - time to configure laptops if non-trivial (e.g. aws credentials and so on)
 - each step of the work to be done
-
-### Stretch Goals
-
-(optional) Describe any closely related work that is not MVP but would be useful.  May be related to some 'Out of Scope' work above.
 
 ## Risks / Challenges / External Dependencies
 

--- a/template.md
+++ b/template.md
@@ -8,7 +8,7 @@
 * Estimate requested: **(date)**
 * Reason: **the rationale for how the estimate will be used/valued**
 
-Add enough information here to contextualize any information stated below, or a link to a document with more info, etc.
+Add enough information here to contextualize any details given below, and/or links to an ADR, a document with more info, etc.
 
 ## Scope Assumptions / Constraints
 
@@ -16,11 +16,25 @@ Document scoping assumptions made and constraints given while producing the esti
 
 ### Assumptions
 
+Assumptions in order to proceed with an approach to the work. Examples:
+- if you're going to be using AWS, management will approve the $$.
+- you can put information X in a config file (assume it is not considered sensitive and it won't change often)
+- new technology X works in a certain way (that you don't have time to confirm, but the documentation is unclear)
+- VM provisioning (call out that it is not included in the estimate)
+- developers already know technologies (specify, e.g. javascript, React, Rails, terraform, whatever)
+
 ### Out of Scope
+Closely related work that this estimate does NOT include.  It may or may not be helpful to have "stretch" goals. Examples:
+- rebuilding the whole index from scratch (as opposed to incremental updates)
+- automating a task (plan is to do it manually at first)
+- providing a nice-to-have that is closely related (e.g. easy way for user to get list of all members in a group)
 
 ## Work To Do
 
-Describe the work in more detail, broken down into chunks of work that help with determining estimate.
+Describe the work in more detail, broken down into chunks of work that help with determining estimate.  Remember to include things like:
+- time to learn any new technologies (at least to the MVP level), e.g. terraform, new language, docker, rails ...
+- time to configure laptops if non-trivial (e.g. aws credentials and so on)
+- each step of the work to be done
 
 ### Stretch Goals
 


### PR DESCRIPTION
In writing up 0002-sinopia-acl, I found out I wanted:

- a section for breaking up the expected work  ... because we are computing estimates from looking at all the chunks and then adding them up, yes?  I note that for sinopia-acl work, there was no ADR, so the estimate *had* to describe the work.  In any case, tho, don't we come up with estimates from thinking about the pieces of work to get it done?

- a section to be able to include stretch goals and possibly add estimates to those

- to distinguish between assumptions and scoping in skimmable sections.